### PR TITLE
Corrected typo in repo name

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,7 +1,7 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: risk-explorer-for-sofware-supply-chains
+Upstream-Name: risk-explorer-for-software-supply-chains
 Upstream-Contact: henrik.plate@sap.com
-Source: https://github.com/sap/risk-explorer-for-sofware-supply-chains
+Source: https://github.com/sap/risk-explorer-for-software-supply-chains
 Disclaimer: The code in this project may include calls to APIs ("API Calls") of
  SAP or third-party products or services developed outside of this project
  ("External Products").
@@ -25,5 +25,5 @@ Disclaimer: The code in this project may include calls to APIs ("API Calls") of
  parties the right to use of access any SAP External Product, through API Calls.
 
 Files: .gitignore CODE_OF_CONDUCT.md CONTRIBUTING.md LICENSE package-lock.json package.json README.md references-template.json src/* public/* .github/*
-Copyright:  2022 SAP SE or an SAP affiliate company and risk-explorer-for-sofware-supply-chains contributors
+Copyright:  2022 SAP SE or an SAP affiliate company and risk-explorer-for-software-supply-chains contributors
 License: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Risk Explorer for Software Supply Chains
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE.txt)
-[![REUSE status](https://api.reuse.software/badge/github.com/sap/risk-explorer-for-sofware-supply-chains)](https://api.reuse.software/info/github.com/sap/risk-explorer-for-sofware-supply-chains)
+[![REUSE status](https://api.reuse.software/badge/github.com/sap/risk-explorer-for-software-supply-chains)](https://api.reuse.software/info/github.com/sap/risk-explorer-for-software-supply-chains)
 
 ## About this project
 
@@ -16,7 +16,7 @@ In more detail, project and tool provide the following information:
 
 ## Requirements and Setup
 
-Simply [access the tool online](https://sap.github.io/risk-explorer-for-sofware-supply-chains/) using your favorite browser. Make sure to enable JavaScript and use a desktop environment for a better experience.
+Simply [access the tool online](https://sap.github.io/risk-explorer-for-software-supply-chains/) using your favorite browser. Make sure to enable JavaScript and use a desktop environment for a better experience.
 
 If you want to run a local version of the code you need to install [Node.js](https://nodejs.dev/learn/how-to-install-nodejs), then from inside the project directory (where `package.json` is located):
 1. Install the required dependencies via `npm install`
@@ -24,7 +24,7 @@ If you want to run a local version of the code you need to install [Node.js](htt
    
 ## Support, Feedback, Contributing
 
-This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://github.com/SAP/risk-explorer-for-sofware-supply-chains/issues). Contribution and feedback are encouraged and always welcome. For more information about how to contribute, the project structure, as well as additional contribution information, see our [Contribution Guidelines](CONTRIBUTING.md).
+This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://github.com/SAP/risk-explorer-for-software-supply-chains/issues). Contribution and feedback are encouraged and always welcome. For more information about how to contribute, the project structure, as well as additional contribution information, see our [Contribution Guidelines](CONTRIBUTING.md).
 
 ## Code of Conduct
 
@@ -32,4 +32,4 @@ We as members, contributors, and leaders pledge to make participation in our com
 
 ## Licensing
 
-Copyright 2022 SAP SE or an SAP affiliate company and Risk Explorer for Software Supply Chains contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/SAP/risk-explorer-for-sofware-supply-chains/).
+Copyright 2022 SAP SE or an SAP affiliate company and Risk Explorer for Software Supply Chains contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/SAP/risk-explorer-for-software-supply-chains/).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attacktree",
-  "homepage": "https://sap.github.io/risk-explorer-for-sofware-supply-chains/",
+  "homepage": "https://sap.github.io/risk-explorer-for-software-supply-chains/",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/src/components/topbar/Topbar.jsx
+++ b/src/components/topbar/Topbar.jsx
@@ -34,7 +34,7 @@ export default class Topbar extends Component {
                             <div className="topbarIconContainer">
 
                                 <span className="logo">
-                                    <a className="logo"  href="https://github.com/SAP/risk-explorer-for-sofware-supply-chains" target="_blank" rel="noreferrer"><GitHubIcon style={{fontSize: "30px",marginTop:"45%"}}></GitHubIcon></a>
+                                    <a className="logo"  href="https://github.com/SAP/risk-explorer-for-software-supply-chains" target="_blank" rel="noreferrer"><GitHubIcon style={{fontSize: "30px",marginTop:"45%"}}></GitHubIcon></a>
                                 </span>
 
                             </div>

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -253,7 +253,7 @@ class Home extends Component {
                                                                     <p>Read about the JSON files and their structure</p>
                                                                 </Grid>
                                                                 <Grid item xs={6}>
-                                                                    <a style={{ color: 'white', textDecoration: 'inherit' }} href="https://github.com/SAP/risk-explorer-for-sofware-supply-chains" target='_blank' rel="noreferrer">
+                                                                    <a style={{ color: 'white', textDecoration: 'inherit' }} href="https://github.com/SAP/risk-explorer-for-software-supply-chains" target='_blank' rel="noreferrer">
                                                                         <Button variant="outlined" style={{ width: '85%' }} size='large'>
 
                                                                             <GitHubIcon />


### PR DESCRIPTION
Renamed `risk-explorer-for-sofware-supply-chains` to `risk-explorer-for-software-supply-chains`