### PR TITLE
Add new example of attack based on resurrection of accounts both for …

### DIFF
--- a/src/data/references.json
+++ b/src/data/references.json
@@ -5574,6 +5574,22 @@
             "year": 2022
         }
         
+    },
+    {
+        "title": "How I hacked CTX and PHPass Modules",
+        "link": "https://sockpuppets.medium.com/how-i-hacked-ctx-and-phpass-modules-656638c6ec5e",
+        "vectors": [
+            {    
+                    "avId": "AV-608",
+                    "avName": "Resurrect Expired Domain Associated With Legitimate Account"
+            }
+        ],
+        "tags": {
+            "ecosystems": ["Rust","Python","GitHub"],
+            "packages": [], 
+            "contents": ["attack"],
+            "year": 2022
+        }
     }
 
 ]


### PR DESCRIPTION
This is to add in the reference list the example : https://sockpuppets.medium.com/how-i-hacked-ctx-and-phpass-modules-656638c6ec5e

Since the attack is valid for both package repositories and on GitHub I attached it to the general attack vector AV-608 Resurrect Expired Domain Associated With Legitimate Account, not scoped to any particular parent AV