### PR TITLE
Added more attacks on npm, Rust and PHP

### DIFF
--- a/src/data/attackvectors.json
+++ b/src/data/attackvectors.json
@@ -94,7 +94,7 @@
     "avId": "AV-205",
     "avName": "Built-in Package",
     "info": [{
-        "Description": "By creating a package whose name is identical to a built-in package (or module) of the respective programming language or ecosystem (for example \"subprocess\" for Python), a victim can be tricked into downloading and installing the malicious package through the package manager rather than using built-in functionality.",
+        "Description": "By creating a package whose name is identical to a built-in package (or module, class, function, etc.) of the respective programming language or ecosystem (for example \"subprocess\" for Python), a victim can be tricked into downloading and installing the malicious package through the package manager rather than using built-in functionality.",
         "Impact": "Create name confusion, resulting in the installation of a malicious package",
         "Mapped Safeguard": []
     }]

--- a/src/data/references.json
+++ b/src/data/references.json
@@ -5616,7 +5616,7 @@
         }
     },
     {
-        "title": "This Week in Malware—Malicious Rust crate, 'colors' typosquats",
+        "title": "This Week in Malware - Malicious Rust crate, 'colors' typosquats",
         "link": "https://blog.sonatype.com/this-week-in-malware-may-13th-edition",
         "vectors": [
             {

--- a/src/data/references.json
+++ b/src/data/references.json
@@ -5596,20 +5596,16 @@
         }
     },
     {
-        "title": "PyPI package 'ctx' and PHP library 'phpass' compromised to steal environment variables",
-        "link": "https://blog.sonatype.com/pypi-package-ctx-compromised-are-you-at-risk",
+        "title": "How I hacked CTX and PHPass Modules",
+        "link": "https://sockpuppets.medium.com/how-i-hacked-ctx-and-phpass-modules-656638c6ec5e",
         "vectors": [
             {
-                "avId": "AV-504",
-                "avName": "Distribute as Package Maintainer"
-            },
-            {
-                "avId": "AV-302",
-                "avName": "Contribute as Maintainer"
+                "avId": "AV-608",
+                "avName": "Resurrect Expired Domain Associated With Legitimate Account"
             }
         ],
         "tags": {
-            "ecosystems": ["Python", "PHP"],
+            "ecosystems": ["Python", "PHP", "Rust"],
             "packages": ["ctx", "phpass"],
             "contents": ["attack"],
             "year": 2022

--- a/src/data/references.json
+++ b/src/data/references.json
@@ -5594,6 +5594,61 @@
             "contents": [],
             "year": 2022
         }
-
+    },
+    {
+        "title": "PyPI package 'ctx' and PHP library 'phpass' compromised to steal environment variables",
+        "link": "https://blog.sonatype.com/pypi-package-ctx-compromised-are-you-at-risk",
+        "vectors": [
+            {
+                "avId": "AV-602",
+                "avName": "Take-over Legitimate Account",
+                "scopeAvId": "AV-504",
+                "scopeAvName": "Distribute as Package Maintainer"
+            },
+            {
+                "avId": "AV-602",
+                "avName": "Take-over Legitimate Account",
+                "scopeAvId": "AV-302",
+                "scopeAvName": "Contribute as Maintainer"
+            }
+        ],
+        "tags": {
+            "ecosystems": ["Python", "PHP"],
+            "packages": ["ctx", "phpass"],
+            "contents": ["attack"],
+            "year": 2022
+        }
+    },
+    {
+        "title": "This Week in Malware—Malicious Rust crate, 'colors' typosquats",
+        "link": "https://blog.sonatype.com/this-week-in-malware-may-13th-edition",
+        "vectors": [
+            {
+                "avId": "AV-203",
+                "avName": "Manipulating Word Separators"
+            }
+        ],
+        "tags": {
+            "ecosystems": ["Rust"],
+            "packages": ["rustdecimal"],
+            "contents": ["attack"],
+            "year": 2022
+        }
+    },
+    {
+        "title": "Remember npm library 'colors'? There's no such thing as 'colors-2.0'",
+        "link": "https://blog.sonatype.com/remember-npm-library-colors-theres-no-such-thing-as-colors-2.0",
+        "vectors": [
+            {
+                "avId": "AV-201",
+                "avName": "Combosquatting"
+            }
+        ],
+        "tags": {
+            "ecosystems": ["JavaScript"],
+            "packages": ["colors2.0", "colors-2.2.0", "colors-3.0"],
+            "contents": ["attack"],
+            "year": 2022
+        }
     }
 ]

--- a/src/data/references.json
+++ b/src/data/references.json
@@ -5642,5 +5642,41 @@
             "contents": ["attack"],
             "year": 2022
         }
+    },
+    {
+        "title": "This week in malware - a 'fix-crash' info-stealer and 500+ malicious npm packages",
+        "link": "https://blog.sonatype.com/this-week-in-malware-a-fix-crash-info-stealer-and-500-malicious-npm-packages",
+        "vectors": [
+            {
+                "avId": "AV-205",
+                "avName": "Built-in Package"
+            }
+        ],
+        "tags": {
+            "ecosystems": ["JavaScript"],
+            "packages": ["advance-string-index", "add-to-unscopables", "..."],
+            "contents": ["attack"],
+            "year": 2022
+        }
+    },
+    {
+        "title": "This week in malware - 400+ npm packages target Azure, Uber, Airbnb developers",
+        "link": "https://blog.sonatype.com/this-week-in-malware-400-npm-packages-target-azure-uber-airbnb-developers",
+        "vectors": [
+            {
+                "avId": "AV-206",
+                "avName": "Brandjacking"
+            },
+            {
+                "avId": "AV-509",
+                "avName": "Abuse Dependency Resolution Mechanism"
+            }
+        ],
+        "tags": {
+            "ecosystems": ["JavaScript"],
+            "packages": ["azure-arm-mariadb-samples-ts", "azure-iot-device-update-samples-js", "...", "uber-origin", "uber-one", "..."],
+            "contents": ["attack"],
+            "year": 2022
+        }
     }
 ]

--- a/src/data/references.json
+++ b/src/data/references.json
@@ -5600,16 +5600,12 @@
         "link": "https://blog.sonatype.com/pypi-package-ctx-compromised-are-you-at-risk",
         "vectors": [
             {
-                "avId": "AV-602",
-                "avName": "Take-over Legitimate Account",
-                "scopeAvId": "AV-504",
-                "scopeAvName": "Distribute as Package Maintainer"
+                "avId": "AV-504",
+                "avName": "Distribute as Package Maintainer"
             },
             {
-                "avId": "AV-602",
-                "avName": "Take-over Legitimate Account",
-                "scopeAvId": "AV-302",
-                "scopeAvName": "Contribute as Maintainer"
+                "avId": "AV-302",
+                "avName": "Contribute as Maintainer"
             }
         ],
         "tags": {


### PR DESCRIPTION
Resolves #22 by adding five references related to attacks on npm, Rust and PHP packages (based name confusion and contributing/distributing as maintainer). Also adjusted the description of AV-205, Built-in Package, to reflect an attack on npm where class and function names were used as package names.