### PR TITLE
Add new examples discussed in issue #39

### DIFF
--- a/src/data/references.json
+++ b/src/data/references.json
@@ -5762,7 +5762,7 @@
      },
      {
         "title": "CloudGuard Spectral detects several malicious packages on PyPI",
-        "link":"https://research.checkpoint.com/2022/cloudguard-spectral-detects-several-malicious-packages-on-pypi-the-official-software-repository-for-python-developers/",
+        "link": "https://research.checkpoint.com/2022/cloudguard-spectral-detects-several-malicious-packages-on-pypi-the-official-software-repository-for-python-developers/",
         "vectors": [
             {
                 "avId": "AV-200",
@@ -5778,7 +5778,7 @@
      },
      {
         "title": "CloudGuard Spectral detects several malicious packages on PyPI",
-        "link":"https://research.checkpoint.com/2022/cloudguard-spectral-detects-several-malicious-packages-on-pypi-the-official-software-repository-for-python-developers/",
+        "link": "https://research.checkpoint.com/2022/cloudguard-spectral-detects-several-malicious-packages-on-pypi-the-official-software-repository-for-python-developers/",
         "vectors": [
             {
                 "avId": "AV-100",
@@ -5791,11 +5791,10 @@
             "contents": ["attack"],
             "year": 2022
          }
-     }, 
-
+     },
      {
         "title": "PyPi python packages caught sending stolen AWS keys to unsecured sites",
-        "link":"https://www.bleepingcomputer.com/news/security/pypi-python-packages-caught-sending-stolen-aws-keys-to-unsecured-sites/",
+        "link":"https://blog.sonatype.com/python-packages-upload-your-aws-keys-env-vars-secrets-to-web",
         "vectors": [
             {
                 "avId": "AV-100",
@@ -5811,7 +5810,7 @@
      },
      {
         "title": "PyPi python packages caught sending stolen AWS keys to unsecured sites",
-        "link":"https://www.bleepingcomputer.com/news/security/pypi-python-packages-caught-sending-stolen-aws-keys-to-unsecured-sites/",
+        "link":"https://blog.sonatype.com/python-packages-upload-your-aws-keys-env-vars-secrets-to-web",
         "vectors": [
             {
                 "avId": "AV-200",
@@ -5825,5 +5824,4 @@
             "year": 2022
          }
      }
-
 ]

--- a/src/data/references.json
+++ b/src/data/references.json
@@ -5759,5 +5759,71 @@
             "contents": ["attack"],
             "year": 2022
          }
+     },
+     {
+        "title": "CloudGuard Spectral detects several malicious packages on PyPI",
+        "link":"https://research.checkpoint.com/2022/cloudguard-spectral-detects-several-malicious-packages-on-pypi-the-official-software-repository-for-python-developers/",
+        "vectors": [
+            {
+                "avId": "AV-200",
+                "avName": "Create Name Confusion with Legitimate Package",
+            }
+        ],
+        "tags": {
+            "ecosystems": ["Python"],
+            "packages": ["ascii2text","zlibsrc"],
+            "contents": ["attack"],
+            "year": 2022
+         }
+     },
+     {
+        "title": "CloudGuard Spectral detects several malicious packages on PyPI",
+        "link":"https://research.checkpoint.com/2022/cloudguard-spectral-detects-several-malicious-packages-on-pypi-the-official-software-repository-for-python-developers/",
+        "vectors": [
+            {
+                "avId": "AV-100",
+                "avName": "Develop and Advertise Distinct Malicious Package from Scratch",
+            }
+        ],
+        "tags": {
+            "ecosystems": ["Python"],
+            "packages": ["Pyg-utils", "Pymocks", "PyProto2", "Test-async", "Free-net-vpn", "Free-net-vpn2", "Browserdiv", "WINRPCexploit"],
+            "contents": ["attack"],
+            "year": 2022
+         }
+     }, 
+
+     {
+        "title": "PyPi python packages caught sending stolen AWS keys to unsecured sites",
+        "link":"https://www.bleepingcomputer.com/news/security/pypi-python-packages-caught-sending-stolen-aws-keys-to-unsecured-sites/",
+        "vectors": [
+            {
+                "avId": "AV-100",
+                "avName": "Develop and Advertise Distinct Malicious Package from Scratch",
+            }
+        ],
+        "tags": {
+            "ecosystems": ["Python"],
+            "packages": ["pygrata", "pygrata-utils", "hkg-sol-utils"],
+            "contents": ["attack"],
+            "year": 2022
+         }
+     },
+     {
+        "title": "PyPi python packages caught sending stolen AWS keys to unsecured sites",
+        "link":"https://www.bleepingcomputer.com/news/security/pypi-python-packages-caught-sending-stolen-aws-keys-to-unsecured-sites/",
+        "vectors": [
+            {
+                "avId": "AV-200",
+                "avName": "Create Name Confusion with Legitimate Package",
+            }
+        ],
+        "tags": {
+            "ecosystems": ["Python"],
+            "packages": ["loglib-modules", "pyg-modules"],
+            "contents": ["attack"],
+            "year": 2022
+         }
      }
+
 ]


### PR DESCRIPTION
This PR adds the examples as discussed in [issue #39](https://github.com/SAP/risk-explorer-for-software-supply-chains/issues/39#issue-1335002279).