### PR TITLE
Change ethos node categorization

### DIFF
--- a/src/components/legend/Legend.jsx
+++ b/src/components/legend/Legend.jsx
@@ -74,7 +74,7 @@ const rows = [
             <circle cx="50" cy="10" class="node" r="10"/>
 
         </g>
-    </svg>, "Attack vectors related to social-engineering attack on project maintainer"),
+    </svg>, "Attack vectors related to social-engineering attack on project maintainer or the change of ethos of the maintainer him/herself"),
 
 createData("Social Engineering",
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20">

--- a/src/data/attackvectors.json
+++ b/src/data/attackvectors.json
@@ -467,7 +467,7 @@
         "Mapped Safeguard": []
     }]
 }, {
-    "avId": "AV-609",
+    "avId": "AV-801",
     "avName": "Change Ethos",
     "info": [{
         "Description": "Project maintainers may change their behavior from benign and ethical to malicious and unethical. Possible intrinsic motivations for such changes are to express political beliefs or dissatifaction about stakeholder behavior, e.g., harassment or lack of user support/contributions. In such cases, a formerly benign maintainer turns into the attacker.",

--- a/src/data/references.json
+++ b/src/data/references.json
@@ -1304,7 +1304,7 @@
         "title": "Open source developer corrupts widely-used libraries, affecting tons of projects",
         "link": "https://www.theverge.com/2022/1/9/22874949/developer-corrupts-open-source-libraries-projects-affected",
         "vectors": [{
-            "avId": "AV-609",
+            "avId": "AV-801",
             "avName": "Change Ethos",
             "scopeAvId": "AV-302",
             "scopeAvName": "Contribute as Maintainer"
@@ -5447,7 +5447,7 @@
         "title": "Alert: peacenotwar module sabotages npm developers in the node-ipc package to protest the invasion of Ukraine",
         "link": "https://snyk.io/blog/peacenotwar-malicious-npm-node-ipc-package-vulnerability/",
         "vectors": [{
-            "avId": "AV-609",
+            "avId": "AV-801",
             "avName": "Change Ethos",
             "scopeAvId": "AV-302",
             "scopeAvName": "Contribute as Maintainer"
@@ -5833,7 +5833,7 @@
         "link":"https://checkmarx.com/blog/new-protestware-found-lurking-in-highly-popular-npm-package/",
         "vectors": [
             {
-                "avId": "AV-609",
+                "avId": "AV-801",
                 "avName": "Change Ethos",
                 "scopeAvId": "AV-304",
                 "scopeAvName": "Contribute as Maintainer"

--- a/src/data/taxonomy.json
+++ b/src/data/taxonomy.json
@@ -86,10 +86,6 @@
                                     "avId": "AV-601"
                                 },
                                 {
-                                    "avName": "Change Ethos",                                    
-                                    "avId": "AV-609"
-                                },
-                                {
                                     "avName": "Take-over Legitimate Account",
                                     "avId": "AV-602",
                                     "children": [{
@@ -121,6 +117,10 @@
                                 {
                                     "avName": "Become a Maintainer",                                    
                                     "avId": "AV-800"
+                                },
+                                {
+                                    "avName": "Change Ethos",                                    
+                                    "avId": "AV-801"
                                 },
                                 {
                                     "avName": "Compromise Maintainer System",                      
@@ -218,10 +218,6 @@
                                     "avId": "AV-601"
                                 },
                                 {
-                                    "avName": "Change Ethos",                                    
-                                    "avId": "AV-609"
-                                },
-                                {
                                     "avName": "Take-over Legitimate Account",
                                     "avId": "AV-602",
                                     "children": [{
@@ -254,6 +250,10 @@
                                 {
                                     "avName": "Become a Maintainer",
                                     "avId": "AV-800"
+                                },
+                                {
+                                    "avName": "Change Ethos",                                    
+                                    "avId": "AV-801"
                                 },
                                 {
                                     "avName": "Compromise Maintainer System",
@@ -377,10 +377,6 @@
                                     "avId": "AV-601"
                                 },
                                 {
-                                    "avName": "Change Ethos",                                    
-                                    "avId": "AV-609"
-                                },
-                                {
                                     "avName": "Take-over Legitimate Account",                                   
                                     "avId": "AV-602",
                                     
@@ -421,6 +417,10 @@
                                     "avName": "Become a Maintainer",
                                     "avId": "AV-800"
                                    
+                                },
+                                {
+                                    "avName": "Change Ethos",                                    
+                                    "avId": "AV-801"
                                 },
                                 {
                                     "avName": "Compromise Maintainer System",


### PR DESCRIPTION
I was re-thinking about the new node "Change ethos" and I think that he should not belong to the AV-6xx nodes, which were intended to belong to the *compromise of a User account* (either the maintainer or the administrator of a system). I think the case of changing intentions and roguing a package if you're the maintainer is different. In fact, in this case you don't have to compromise any account (since you're already the owner). That's why my proposal is to make it sibling to the set of  nodes [(AV-800) Become a Maintainer](https://sap.github.io/risk-explorer-for-software-supply-chains/#/attacktree?av=AV-800). And this in fact would perfectly match the fact that the new node "Change ethos" will appear only below `Contribute as Maintainer`, `Tamper Build Job as Maintainer`, `Distribute as Package Maintainer`

![Screenshot 2022-09-20 at 15 08 18](https://user-images.githubusercontent.com/44639444/191266032-5334267a-3a26-426c-bdb7-fcea71c2ecb6.png)

Note: This has been reflected also in the legend of the yellow-striped nodes
