### PR TITLE
Fixed inconsistencies in references.json.

### DIFF
--- a/src/data/references.json
+++ b/src/data/references.json
@@ -4553,8 +4553,6 @@
         }, {
             "avId": "AV-301",
             "avName": "Introduce Malicious Code through Hypocrite Merge Request"
-        }, {
-
         }],
         "safeguards": [{
             "sgId": "SG-016",
@@ -4579,13 +4577,13 @@
         "vectors": [{
             "avId": "AV-000",
             "avName": "Conduct Open-Source Supply Chain Attack"
-        }, {
-            "sgId": "SG-003",
-            "sgName": "Software Composition Analysis (SCA)"
         }],
         "safeguards": [{
             "sgId": "SG-014",
             "sgName": "Code Isolation and Sandboxing"
+        }, {
+            "sgId": "SG-003",
+            "sgName": "Software Composition Analysis (SCA)"
         }, {
             "sgId": "SG-001",
             "sgName": "Software Bill of Materials (SBOM)"


### PR DESCRIPTION
While trying to parse the data from references.json I found out that in one case an attack vector object was added without any <key, value> pair.

Another inconsistency I found was that a safeguard was added to the attack vector list.

I think these are might be small inconsistencies and so I created a pull request without creating an issue.