### PR TITLE
Adding AI package hallucination attack vector

### DIFF
--- a/src/data/attackvectors.json
+++ b/src/data/attackvectors.json
@@ -123,6 +123,14 @@
         "Mapped Safeguard": []
     }]
 }, {
+    "avId": "AV-209",
+    "avName": "AI Package Hallucination",
+    "info": [{
+        "Description": "Generative AI platforms, such as ChatGPT, have the capability to generate responses and recommendations based on the patterns and information learned during training. While these platforms provide valuable assistance, it's important to note that the responses generated may not always align with reality and can include elements that do not exist. <br>In the context of coding tasks, developers may seek recommendations for packages that can solve their specific needs. However, the generative AI model might suggest packages that are not actually present in legitimate package repositories like NPM or PyPI. This creates an opportunity for attackers to exploit the platform by crafting questions that prompt the AI to generate non-existent package names. <br>The intention of such an attack would be to deceive developers who rely on the generative AI's recommendations. The attackers could then publish malicious packages under these fabricated names, leading unsuspecting developers into using them. ",
+        "Impact": "Create name confusion, resulting in the installation of a malicious package",
+        "Mapped Safeguard": []
+    }]
+}, {
     "avId": "AV-001",
     "avName": "Subvert Legitimate Package",
     "info": [{

--- a/src/data/references.json
+++ b/src/data/references.json
@@ -6367,6 +6367,19 @@
             "packages": ["colorslib","httpslib","libhttps"]
 
         }
+    },
+    {
+        "title": "Can you trust ChatGPT’s package recommendations?",
+        "link": "https://vulcan.io/blog/ai-hallucinations-package-risk",
+        "vectors": [{
+            "avId": "AV-209",
+            "avName": "AI Package Hallucination"
+        }],
+        "tags": {
+            "contents": ["attack"],
+            "year": 2023
+
+        }
     }
   
     

--- a/src/data/taxonomy.json
+++ b/src/data/taxonomy.json
@@ -33,12 +33,16 @@
                     "avId": "AV-206"
                 },
                 {
+                    "avName": "Similarity Attack",               
+                    "avId": "AV-207"
+                },
+                {
                     "avName": "Omitting Scope or Namespace",               
                     "avId": "AV-208"
                 },
                 {
-                    "avName": "Similarity Attack",               
-                    "avId": "AV-207"
+                    "avName": "AI Package Hallucination",               
+                    "avId": "AV-209"
                 }
             ]
         },


### PR DESCRIPTION
As discussed in the related [issue](https://github.com/SAP/risk-explorer-for-software-supply-chains/issues/88), we add the new attack vector related to AI package hallucination.
I've added description and associated reference.

@henrikplate @serenaponta 